### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/tools/arm_pack_manager/__init__.py
+++ b/tools/arm_pack_manager/__init__.py
@@ -25,7 +25,7 @@ from tools.flash_algo import PackFlashAlgo
 
 warnings.filterwarnings("ignore")
 
-from fuzzywuzzy import process
+from rapidfuzz import process
 
 RootPackURL = "http://www.keil.com/pack/index.idx"
 
@@ -335,7 +335,7 @@ class Cache () :
         stdout.write("\n")
 
     def find_device(self, match) :
-        choices = process.extract(match, self.index.keys(), limit=len(self.index))
+        choices = process.extract(match, self.index.keys(), limit=None)
         choices = sorted([(v, k) for k, v in choices], reverse=True)
         if choices : choices = list(takewhile(lambda t: t[0] == choices[0][0], choices))
         return [(v, self.index[v]) for k,v in choices]

--- a/tools/arm_pack_manager/pack_manager.py
+++ b/tools/arm_pack_manager/pack_manager.py
@@ -5,7 +5,7 @@ from tools.arm_pack_manager import Cache
 from os.path import basename, join, dirname, exists
 from os import makedirs
 from itertools import takewhile
-from fuzzywuzzy import process
+from rapidfuzz import process
 from .arm_pack_manager import Cache
 
 parser = argparse.ArgumentParser(description='A Handy little utility for keeping your cache of pack files up to date.')

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -10,4 +10,4 @@ mbed-ls>=0.2.13
 mbed-host-tests>=1.1.2
 mbed-greentea>=0.2.24
 beautifulsoup4>=4
-fuzzywuzzy>=0.11
+rapidfuzz>=0.7.3


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/maxbachmann/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy